### PR TITLE
Fix for SEO, Fix Document

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,22 +1,30 @@
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from './src/locales';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://astro-i18n-starter.pages.dev',
-  integrations: [mdx(), sitemap()],
+  site: 'https://astro-i18n-starter.pages.dev', // Set your site's URL
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'ja', 'zh-cn', 'ar'],
+    defaultLocale: DEFAULT_LOCALE_SETTING,
+    locales: Object.keys(LOCALES_SETTING),
     routing: {
       prefixDefaultLocale: true,
       redirectToDefaultLocale: false,
     },
   },
-  markdown: {
-    shikiConfig: {
-      theme: 'red',
-    },
-  },
+  integrations: [
+    mdx(),
+    sitemap({
+      i18n: {
+        defaultLocale: DEFAULT_LOCALE_SETTING,
+        locales: Object.fromEntries(
+          Object.entries(LOCALES_SETTING).map(
+            ([key, value]) => [key, value.lang ?? key]
+          )
+        ),
+      },
+    })
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "astro-i18n-starter",
 	"description": "A starter for Astro with i18n support",
-	"version": "2.0.1",
+	"version": "3.0.0",
 	"private": false,
 	"license": "MIT",
 	"homepage": "https://astro-i18n-starter.pages.dev/",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://astro-i18n-starter.pages.dev/sitemap-index.xml

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,22 +1,22 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-import { type Multilingual } from "@/i18n";
+import type { Multilingual } from "@/i18n";
 
 export const SITE_TITLE: string | Multilingual = "Astro i18n Starter";
 
 export const SITE_DESCRIPTION: string | Multilingual = {
-  en: "A starter template for Astro with i18n support.",
-  ja: "i18n 対応の Astro スターターテンプレート。",
-  "zh-cn": "具有 i18n 支持的 Astro 入门模板。",
-  ar: "قالب بداية لـ Astro مع دعم i18n.",
+	en: "A starter template for Astro with i18n support.",
+	ja: "i18n 対応の Astro スターターテンプレート。",
+	"zh-cn": "具有 i18n 支持的 Astro 入门模板。",
+	ar: "قالب بداية لـ Astro مع دعم i18n.",
 };
 
 export const X_ACCOUNT: string | Multilingual = "@psephopaiktes";
 
 export const NOT_TRANSLATED_CAUTION: string | Multilingual = {
-  en: "This page is not available in your language.",
-  ja: "このページはご利用の言語でご覧いただけません。",
-  "zh-cn": "此页面不支持您的语言。",
-  ar: "هذه الصفحة غير متوفرة بلغتك.",
+	en: "This page is not available in your language.",
+	ja: "このページはご利用の言語でご覧いただけません。",
+	"zh-cn": "此页面不支持您的语言。",
+	ar: "هذه الصفحة غير متوفرة بلغتك.",
 };

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -53,6 +53,7 @@ const localeDescription = description || t(SITE_DESCRIPTION);
 
     <!-- icon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon alternate" sizes="64x64" type="image/png" href="/favicon.png">
     <link rel="icon" sizes="192x192" href="/android-chrome.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="color-scheme" content="light dark" />

--- a/src/locales.ts
+++ b/src/locales.ts
@@ -1,29 +1,31 @@
-// locale settings for this theme
+// locales settings for this theme
+// Set the languages you want to support on your site.
 // https://astro-i18n-starter.pages.dev/setup/
 
 export const DEFAULT_LOCALE_SETTING: string = "en";
 
-export const LOCALES_SETTING: LocaleSetting = {
-  "en": {
-    "label": "English"
-  },
-  "ja": {
-    "label": "日本語"
-  },
-  "zh-cn": {
-    "label": "简体中文",
-    "lang": "zh-CN"
-  },
-  "ar": {
-    "label": "العربية",
-    "dir": "rtl"
-  },
-};
-
 interface LocaleSetting {
-  [key: Lowercase<string>]: {
-    label: string;
-    lang?: string;
-    dir?: 'rtl' | 'ltr';
-  };
+	[key: Lowercase<string>]: {
+		label: string;
+		lang?: string;
+		dir?: "rtl" | "ltr";
+	};
 } // refer: https://starlight.astro.build/reference/configuration/#locales
+
+export const LOCALES_SETTING: LocaleSetting = {
+	en: {
+		label: "English",
+		lang: "en-US",
+	},
+	ja: {
+		label: "日本語",
+	},
+	"zh-cn": {
+		label: "简体中文",
+		lang: "zh-CN",
+	},
+	ar: {
+		label: "العربية",
+		dir: "rtl",
+	},
+};

--- a/src/pages/ar/page.mdx
+++ b/src/pages/ar/page.mdx
@@ -1,27 +1,28 @@
 ---
 layout: "@/layouts/Article.astro"
 title: "إضافة صفحة"
-description: "إضافة وإدارة صفحات متعددة اللغات"
+description: "إضافة وإدارة الصفحات متعددة اللغات"
 ---
 import PageHeadline from "@/components/PageHeadline.astro";
 import { SITE_TITLE } from "@/consts";
 
 <PageHeadline title={frontmatter.title} />
 
-يوجد عدة طرق لإنشاء صفحات متعددة اللغات باستخدام { SITE_TITLE }.
+هناك عدة طرق لإنشاء صفحات متعددة اللغات في { SITE_TITLE }.
 
 
-## إذا كنت ترغب في تقسيم الملفات حسب اللغة
 
-أنشئ مجلدًا لكل لغة تحت `pages` وأضف الملفات بتنسيق Astro أو Markdown.
+## إذا كنت تريد فصل الملفات لكل لغة
+
+قم بإنشاء مجلد لكل لغة تحت `pages` وأضف الملفات بتنسيق Astro أو Markdown.
 
 ```text
 src/pages
 ├── en/
-│   └── page-1.astro
+│   ├── page-1.astro
 │   └── page-2.mdx
-└── ja/
-  └── page-1.astro
+└── ar/
+  ├── page-1.astro
   └── page-2.mdx
 ```
 
@@ -29,22 +30,23 @@ src/pages
 
 * /en/page-1/index.html
 * /en/page-2/index.html
-* /ja/page-1/index.html
-* /ja/page-2/index.html
+* /ar/page-1/index.html
+* /ar/page-2/index.html
 
 
-## إذا كنت ترغب في إدارة الصفحات في ملف واحد
 
-إذا كانت النصوص غير كبيرة جدًا، يمكنك استخدام ميزة [توجيه Astro الديناميكي](https://docs.astro.build/en/guides/routing/#dynamic-routes) لإنشاء صفحات اللغات المختلفة من ملف واحد بشكل دينامي.
+## إذا كنت تريد إدارة كل شيء في ملف واحد
+
+إذا لم يكن هناك الكثير من النصوص في الصفحة، يمكنك استخدام ميزة [التوجيه الديناميكي في Astro](https://docs.astro.build/en/guides/routing/#dynamic-routes) لإنشاء صفحات لكل لغة ديناميكيًا من ملف واحد.
 
 ```text
 src/pages
 └── [lang]/
-    └── page-1.astro
+    ├── page-1.astro
     └── page-2.astro
 ```
 
-استورد كائن `LOCALES` داخل الملف واستخدم دالة `getStaticPaths()` في Astro لإنشاء المسارات الديناميكية.
+داخل الملف، قم باستيراد كائن `LOCALES` واستخدم دالة `getStaticPaths()` في Astro لإنشاء المسارات الديناميكية.
 
 ```astro
 ---
@@ -61,49 +63,50 @@ export const getStaticPaths = () =>
 
 * /en/page-1/index.html
 * /en/page-2/index.html
-* /ja/page-1/index.html
-* /ja/page-2/index.html
+* /ar/page-1/index.html
+* /ar/page-2/index.html
 
-## إذا كنت ترغب في استخدام مجموعة المحتوى
 
-إذا كنت ترغب في إدارة صفحات مثل المدونات أو الأخبار باستخدام ملفات Markdown، يمكنك استخدام ميزة [مجموعة المحتوى في Astro]().
 
-#### الدليل
+## إذا كنت تريد استخدام Content Collection
+
+إذا كنت تريد إدارة صفحات المدونة أو الأخبار بملفات Markdown، يمكنك استخدام ميزة Content Collection في Astro.
+
+#### Directory
 
 ```text
 src/
-├── content/
-│   ├── config.ts
-│   ├── blog/en/
-│   │   └── first-post.md
+├── content.config.ts
+├── blog/
+│   ├── en/
+│   │   ├── first-post.md
 │   │   └── second-post.md
-│   └── blog/ja/
-│        └── first-post.md
+│   └── ar/
+│        ├── first-post.md
 │        └── second-post.md
 └── pages/[lang]/blog/
-  └── index.astro
-  └── [...slug].astro
+  ├── index.astro
+  └── [...id].astro
 ```
 
-#### pages/[lang]/blog/[...slug].astro
+#### pages/[lang]/blog/[...id].astro
 
 ```astro
 ---
-import Layout from "@/layouts/Article.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
 
   return posts.map((post) => {
-    const [lang, ...slug] = post.slug.split("/");
-    return { params: { lang, slug: slug.join("/") || undefined }, props: post };
+    const [lang, ...id] = post.id.split("/");
+    return { params: { lang, id: id.join("/") || undefined }, props: post };
   });
 }
 ---
 ```
 
 
-لمزيد من التفاصيل، يرجى الاطلاع على وثائق Astro.
+لمزيد من التفاصيل، يرجى مراجعة وثائق Astro.
 
-> [مجموعات المحتوى | الوثائق](https://docs.astro.build/en/guides/content-collections/)
+> [Content Collections | Docs](https://docs.astro.build/en/guides/content-collections/)

--- a/src/pages/ar/setup.mdx
+++ b/src/pages/ar/setup.mdx
@@ -8,7 +8,6 @@ import { SITE_TITLE } from "@/consts";
 
 <PageHeadline title={frontmatter.title} />
 
-
 ## إنشاء المشروع
 
 ```sh
@@ -17,103 +16,91 @@ npm create astro@latest -- --template psephopaiktes/astro-i18n-starter
 
 ## التكوين
 
+### 1. تكوين /src/locales.ts
 
-### 1. تكوين astro.config.mjs
+أولاً، قم بتحديث ملف إعدادات اللغة.
 
-قم بتعيين `defaultLocale` و `locales` في ملف تكوين Astro.
+قم بتعيين اللغة الافتراضية في `DEFAULT_LOCALE_SETTING` وقائمة اللغات المطلوبة في `LOCALES_SETTING`. يتبع هذا [تكوين Starlight](https://starlight.astro.build/reference/configuration/#locales).
+
+```ts
+// تعيين اللغة الافتراضية لموقعك.
+export const DEFAULT_LOCALE_SETTING: string = "en";
+
+export const LOCALES_SETTING: LocaleSetting = {
+    // إضافة أو إزالة اللغات المدعومة.
+    en: {
+        label: "English",
+        lang: "en-US", // اختياري
+    },
+    ja: {
+        label: "日本語",
+    },
+    "zh-cn": {
+        label: "简体中文",
+        lang: "zh-CN",
+    },
+    ar: {
+        label: "العربية",
+        dir: "rtl", // اختياري
+    },
+};
+```
+
+يرجى الرجوع إلى الرابط التالي للحصول على معلومات حول رموز اللغات.
+
+> [lang - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+
+### 2. تكوين astro.config.mjs
+
+قم بتعيين عنوان URL الخاص بك في `site`.
 
 ```diff
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from './src/locales';
 
-// https://astro.build/config
 export default defineConfig({
-    site: 'https://astro-i18n-starter.pages.dev',
-    integrations: [mdx(), sitemap()],
-    i18n: {
-+   defaultLocale: 'en',
-+   locales: ['en', 'ja', 'zh-cn', 'ar'],
-        routing: {
-            prefixDefaultLocale: true,
-            redirectToDefaultLocale: false,
-        },
+- site: 'https://astro-i18n-starter.pages.dev',
++ site: 'https://your-site.com',
+  i18n: {
+    defaultLocale: DEFAULT_LOCALE_SETTING,
+    locales: Object.keys(LOCALES_SETTING),
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: false,
     },
-    markdown: {
-        shikiConfig: {
-            theme: 'one-dark-pro',
-        },
-    },
-});
+  },
+...
 ```
 
 يرجى الرجوع إلى الوثائق الرسمية للحصول على خيارات التكوين المفصلة لـ Astro.
 
-> [مرجع التكوين | الوثائق](https://docs.astro.build/en/reference/configuration-reference/)
+* [مرجع التكوين | Docs](https://docs.astro.build/en/reference/configuration-reference/)
+* [التوجيه الدولي (i18n) | Docs](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
 
-> [التوجيه الدولي (i18n) | الوثائق](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
-
-لا يُنصح بتغيير إعدادات `prefixDefaultLocale` و `redirectToDefaultLocale`. { SITE_TITLE } يدير عملية إعادة التوجيه باستخدام جافا سكريبت على الجانب العميل. إذا لم يحتوي عنوان URL على لغة، فسيتم إعادة التوجيه إلى اللغة الافتراضية. على سبيل المثال، سيتم إعادة التوجيه من `/setup/` إلى `/en/setup/`.
-
-
-### 2. تكوين /src/locales.ts
-
-بالمثل، قم بتحديث ملف التكوين لـ { SITE_TITLE }.
-
-قم بتعيين اللغة الافتراضية في `DEFAULT_LOCALE_SETTING` وقائمة اللغات المرغوبة في `LOCALES_SETTING`. يتبع هذا [تكوين `locales` في Starlight](https://starlight.astro.build/reference/configuration/#locales).
-
-```ts
-export const DEFAULT_LOCALE_SETTING = "en";
-
-export const LOCALES_SETTING: LocaleSetting = {
-    "en": {
-        "label": "الإنجليزية"
-    },
-    "ja": {
-        "label": "اليابانية"
-    },
-    "zh-cn": {
-        "label": "الصينية المبسطة",
-        "lang": "zh-CN"
-    },
-    "ar": {
-        "label": "العربية",
-        "dir": "rtl"
-    },
-};
-
-interface LocaleSetting {
-    [key: Lowercase<string>]: {
-        label: string;
-        lang?: string;
-        dir?: 'rtl' | 'ltr';
-    };
- }
-```
-
-يرجى الرجوع إلى الرابط التالي للحصول على معلومات حول رموز اللغة.
-
-> [lang - HTML: لغة ترميز النص الفائق | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-
+ملاحظة: لا يُنصح بتغيير إعدادات `prefixDefaultLocale` و `redirectToDefaultLocale`. { SITE_TITLE } يدير عملية إعادة التوجيه باستخدام JavaScript من جانب العميل. إذا لم يحتوي عنوان URL على لغة، فسيتم إعادة التوجيه إلى اللغة الافتراضية. على سبيل المثال، سيتم إعادة توجيه `/setup/` إلى `/en/setup/`.
 
 ## هيكل المشروع
 
-اتبع [هيكل المشروع Astro](https://docs.astro.build/en/basics/project-structure/).
+يتبع [هيكل مشروع Astro](https://docs.astro.build/en/basics/project-structure/).
 
 ```text
 src/
 ├── assets/
 │   └── en/, ja/ ...
+├── blog/
+│   └── en/, ja/ ...
 ├── components/
 │   └── i18n/
-├── content/
-│   │  blog/
-│   └── config.ts
 ├── layouts/
 ├── pages/
-│   └── [lang]/
-│   └── en/, ja/ ...
+│   ├── [lang]/
+│   ├── en/, ja/ ...
+│   ├── 404.astro
+│   └── index.astro
 ├── styles/
+├── content.config.ts
 ├── consts.ts
 ├── i18n.ts
 └── locales.ts
@@ -121,17 +108,17 @@ src/
 
 ### src/components/i18n
 
-المجلد لمكونات واجهة المستخدم المستخدمة في مواقع الويب متعددة اللغات.
+دليل لمكونات واجهة المستخدم المستخدمة في المواقع متعددة اللغات.
 
 ### src/pages
 
-- يقوم الملفات في `src/pages/[lang]/` بإنشاء ملفات HTML لكل لغة بشكل ديناميكي من ملف `.astro` واحد.
-- يمكنك إنشاء ملفات HTML لكل لغة من المجلدات مثل `src/pages/en/`، `src/pages/ja/`، إلخ.
+- الملفات تحت `src/pages/[lang]/` تولد ملفات HTML لكل لغة ديناميكيًا من ملف `.astro` واحد.
+- يمكنك أيضًا توليد ملفات HTML لكل لغة من مجلدات مثل `src/pages/en/`, `src/pages/ja/`, إلخ.
 
 ### src/consts.ts
 
-ملف للبيانات الثابتة التي يمكن استيرادها واستخدامها داخل المشروع. يمكن حذفه أيضًا إذا لم يكن مطلوبًا.
+ملف للبيانات الثابتة التي يمكن استيرادها واستخدامها داخل المشروع. يمكن أيضًا حذفه إذا لم يكن مطلوبًا.
 
 ### src/i18n.ts
 
-ملف يحتوي على تعريفات الوظائف المستخدمة في { SITE_TITLE }. عمومًا، لا يوجد حاجة لتحرير هذا الملف.
+ملف يحتوي على تعريفات الدوال المستخدمة في { SITE_TITLE }. لا يوجد عادةً حاجة لتحرير هذا الملف.

--- a/src/pages/en/page.mdx
+++ b/src/pages/en/page.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "@/layouts/Article.astro"
 title: "Adding Pages"
-description: "Adding and managing multilingual pages"
+description: "About adding and managing multilingual pages"
 ---
 import PageHeadline from "@/components/PageHeadline.astro";
 import { SITE_TITLE } from "@/consts";
@@ -11,17 +11,18 @@ import { SITE_TITLE } from "@/consts";
 There are several ways to create multilingual pages with { SITE_TITLE }.
 
 
-## Separating Files by Language
+
+## If you want to separate files by language
 
 Create folders for each language under `pages` and add files in Astro or Markdown format.
 
 ```text
 src/pages
 ├── en/
-│   └── page-1.astro
+│   ├── page-1.astro
 │   └── page-2.mdx
 └── ja/
-  └── page-1.astro
+  ├── page-1.astro
   └── page-2.mdx
 ```
 
@@ -33,14 +34,15 @@ The following pages will be generated:
 * /ja/page-2/index.html
 
 
-## Managing in a Single File
 
-If the amount of page content is not too large, you can use Astro's dynamic routing feature to generate pages for each language dynamically from a single file.
+## If you want to manage in a single file
+
+If the amount of text on the page is not too large, you can use [Astro's dynamic routing](https://docs.astro.build/en/guides/routing/#dynamic-routes) feature to dynamically generate pages for each language from a single file.
 
 ```text
 src/pages
 └── [lang]/
-    └── page-1.astro
+    ├── page-1.astro
     └── page-2.astro
 ```
 
@@ -64,46 +66,47 @@ The following pages will be generated:
 * /ja/page-1/index.html
 * /ja/page-2/index.html
 
-## Using Content Collection
 
-If you want to manage pages like blogs or news using Markdown files, you can use Astro's Content Collection feature.
+
+## If you want to use Content Collection
+
+If you want to manage pages such as blogs or news in Markdown files, you can use Astro's content collection feature.
 
 #### Directory
 
 ```text
 src/
-├── content/
-│   ├── config.ts
-│   ├── blog/en/
-│   │   └── first-post.md
+├── content.config.ts
+├── blog/
+│   ├── en/
+│   │   ├── first-post.md
 │   │   └── second-post.md
-│   └── blog/ja/
-│        └── first-post.md
+│   └── ja/
+│        ├── first-post.md
 │        └── second-post.md
 └── pages/[lang]/blog/
-  └── index.astro
-  └── [...slug].astro
+  ├── index.astro
+  └── [...id].astro
 ```
 
-#### pages/[lang]/blog/[...slug].astro
+#### pages/[lang]/blog/[...id].astro
 
 ```astro
 ---
-import Layout from "@/layouts/Article.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
 
   return posts.map((post) => {
-    const [lang, ...slug] = post.slug.split("/");
-    return { params: { lang, slug: slug.join("/") || undefined }, props: post };
+    const [lang, ...id] = post.id.split("/");
+    return { params: { lang, id: id.join("/") || undefined }, props: post };
   });
 }
 ---
 ```
 
 
-Please refer to the Astro documentation for more details.
+For more details, please check Astro's documentation.
 
 > [Content Collections | Docs](https://docs.astro.build/en/guides/content-collections/)

--- a/src/pages/en/setup.mdx
+++ b/src/pages/en/setup.mdx
@@ -9,91 +9,82 @@ import { SITE_TITLE } from "@/consts";
 <PageHeadline title={frontmatter.title} />
 
 
+
 ## Project Creation
 
 ```sh
 npm create astro@latest -- --template psephopaiktes/astro-i18n-starter
 ```
 
+
+
 ## Configuration
 
+### 1. Configure /src/locales.ts
 
-### 1. Configure astro.config.mjs
+First, update the language settings file.
 
-Set `defaultLocale` and `locales` in the astro configuration file.
-
-```diff
-import mdx from '@astrojs/mdx';
-import sitemap from '@astrojs/sitemap';
-import { defineConfig } from 'astro/config';
-
-// https://astro.build/config
-export default defineConfig({
-    site: 'https://astro-i18n-starter.pages.dev',
-    integrations: [mdx(), sitemap()],
-    i18n: {
-+   defaultLocale: 'en',
-+   locales: ['en', 'ja', 'zh-cn', 'ar'],
-        routing: {
-            prefixDefaultLocale: true,
-            redirectToDefaultLocale: false,
-        },
-    },
-    markdown: {
-        shikiConfig: {
-            theme: 'one-dark-pro',
-        },
-    },
-});
-```
-
-Please refer to the official documentation for detailed configuration options for Astro.
-
-> [Configuration Reference | Docs](https://docs.astro.build/en/reference/configuration-reference/)
-
-> [Internationalization (i18n) Routing | Docs](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
-
-Changing the settings of `prefixDefaultLocale` and `redirectToDefaultLocale` is not recommended. { SITE_TITLE } manages the redirect process with client-side JavaScript. If the URL does not contain a locale, it will redirect to the default locale. For example, `/setup/` will be redirected to `/en/setup/`.
-
-
-### 2. Configure /src/locales.ts
-
-Similarly, update the configuration file for { SITE_TITLE }.
-
-Set the default locale in `DEFAULT_LOCALE_SETTING` and the list of desired locales in `LOCALES_SETTING`. This follows the [Starlight `locales` configuration](https://starlight.astro.build/reference/configuration/#locales).
+Set the default locale in `DEFAULT_LOCALE_SETTING` and the list of desired locales in `LOCALES_SETTING`. This follows the [Starlight configuration](https://starlight.astro.build/reference/configuration/#locales).
 
 ```ts
-export const DEFAULT_LOCALE_SETTING = "en";
+// Set your site's default locale.
+export const DEFAULT_LOCALE_SETTING: string = "en";
 
 export const LOCALES_SETTING: LocaleSetting = {
-    "en": {
-        "label": "English"
-    },
-    "ja": {
-        "label": "日本語"
-    },
-    "zh-cn": {
-        "label": "简体中文",
-        "lang": "zh-CN"
-    },
-    "ar": {
-        "label": "العربية",
-        "dir": "rtl"
-    },
+    // Add or remove support locales.
+	en: {
+		label: "English",
+		lang: "en-US", // optional
+	},
+	ja: {
+		label: "日本語",
+	},
+	"zh-cn": {
+		label: "简体中文",
+		lang: "zh-CN",
+	},
+	ar: {
+		label: "العربية",
+		dir: "rtl", // optional
+	},
 };
-
-interface LocaleSetting {
-    [key: Lowercase<string>]: {
-        label: string;
-        lang?: string;
-        dir?: 'rtl' | 'ltr';
-    };
- }
 ```
 
 Please refer to the following link for information on language codes.
 
 > [lang - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+
+### 2. Configure astro.config.mjs
+
+Set your URL in `site`.
+
+```diff
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
+import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from './src/locales';
+
+export default defineConfig({
+- site: 'https://astro-i18n-starter.pages.dev',
++ site: 'https://your-site.com',
+  i18n: {
+    defaultLocale: DEFAULT_LOCALE_SETTING,
+    locales: Object.keys(LOCALES_SETTING),
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: false,
+    },
+  },
+...
+```
+
+Please refer to the official documentation for detailed configuration options for Astro.
+
+* [Configuration Reference | Docs](https://docs.astro.build/en/reference/configuration-reference/)
+* [Internationalization (i18n) Routing | Docs](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
+
+note: Changing the settings of `prefixDefaultLocale` and `redirectToDefaultLocale` is not recommended. { SITE_TITLE } manages the redirect process with client-side JavaScript. If the URL does not contain a locale, it will redirect to the default locale. For example, `/setup/` will be redirected to `/en/setup/`.
+
 
 
 ## Project Structure
@@ -104,16 +95,18 @@ Follows the [Astro project structure](https://docs.astro.build/en/basics/project
 src/
 ├── assets/
 │   └── en/, ja/ ...
+├── blog/
+│   └── en/, ja/ ...
 ├── components/
 │   └── i18n/
-├── content/
-│   │  blog/
-│   └── config.ts
 ├── layouts/
 ├── pages/
-│   └── [lang]/
-│   └── en/, ja/ ...
+│   ├── [lang]/
+│   ├── en/, ja/ ...
+│   ├── 404.astro
+│   └── index.astro
 ├── styles/
+├── content.config.ts
 ├── consts.ts
 ├── i18n.ts
 └── locales.ts

--- a/src/pages/ja/page.mdx
+++ b/src/pages/ja/page.mdx
@@ -11,6 +11,7 @@ import { SITE_TITLE } from "@/consts";
 { SITE_TITLE } で多言語のページを作成する方法はいくつか存在します。
 
 
+
 ## 言語ごとにファイルを分けたい場合
 
 `pages` の下に言語ごとにフォルダを作成し、Astro形式やMarkdown形式でファイルを追加します。
@@ -18,10 +19,10 @@ import { SITE_TITLE } from "@/consts";
 ```text
 src/pages
 ├── en/
-│   └── page-1.astro
+│   ├── page-1.astro
 │   └── page-2.mdx
 └── ja/
-     └── page-1.astro
+     ├── page-1.astro
      └── page-2.mdx
 ```
 
@@ -33,6 +34,7 @@ src/pages
 * /ja/page-2/index.html
 
 
+
 ## ひとつのファイルで管理したい場合
 
 ページ内の文章量があまり多くない場合は、[Astroの動的ルーティング](https://docs.astro.build/en/guides/routing/#dynamic-routes)機能を使用して、ひとつのファイルから動的に各言語のページを生成できます。
@@ -40,7 +42,7 @@ src/pages
 ```text
 src/pages
 └── [lang]/
-    └── page-1.astro
+    ├── page-1.astro
     └── page-2.astro
 ```
 
@@ -64,40 +66,41 @@ export const getStaticPaths = () =>
 * /ja/page-1/index.html
 * /ja/page-2/index.html
 
+
+
 ## Content Collection を利用したい場合
 
-ブログやニュース等のページをMarkdownファイルで管理したい場合は、[Astroのコンテンツコレクション]()機能を利用できます。
+ブログやニュース等のページをMarkdownファイルで管理したい場合は、Astroのコンテンツコレクション機能を利用できます。
 
 #### Directory
 
 ```text
 src/
-├── content/
-│   ├── config.ts
-│   ├── blog/en/
-│   │   └── first-post.md
+├── content.config.ts
+├── blog/
+│   ├── en/
+│   │   ├── first-post.md
 │   │   └── second-post.md
-│   └── blog/ja/
-│        └── first-post.md
+│   └── ja/
+│        ├── first-post.md
 │        └── second-post.md
 └── pages/[lang]/blog/
-     └── index.astro
-     └── [...slug].astro
+     ├── index.astro
+     └── [...id].astro
 ```
 
-#### pages/[lang]/blog/[...slug].astro
+#### pages/[lang]/blog/[...id].astro
 
 ```astro
 ---
-import Layout from "@/layouts/Article.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
 
   return posts.map((post) => {
-    const [lang, ...slug] = post.slug.split("/");
-    return { params: { lang, slug: slug.join("/") || undefined }, props: post };
+    const [lang, ...id] = post.id.split("/");
+    return { params: { lang, id: id.join("/") || undefined }, props: post };
   });
 }
 ---

--- a/src/pages/ja/setup.mdx
+++ b/src/pages/ja/setup.mdx
@@ -1,12 +1,13 @@
 ---
 layout: "@/layouts/Article.astro"
 title: "初期設定"
-description: "初期設定方法について"
+description: "セットアッププロセスについて"
 ---
 import PageHeadline from "@/components/PageHeadline.astro";
 import { SITE_TITLE } from "@/consts";
 
 <PageHeadline title={frontmatter.title} />
+
 
 
 ## プロジェクトの作成
@@ -15,123 +16,111 @@ import { SITE_TITLE } from "@/consts";
 npm create astro@latest -- --template psephopaiktes/astro-i18n-starter
 ```
 
+
+
 ## 設定
 
+### 1. /src/locales.ts の設定
 
-### 1. astro.config.mjs の設定
+まず、言語設定ファイルを更新します。
 
-astroの設定ファイルに`defaultLocale`と`locales`を設定します。
+`DEFAULT_LOCALE_SETTING` にデフォルトのロケールを設定し、`LOCALES_SETTING` に希望するロケールのリストを設定します。これは [Starlightの設定](https://starlight.astro.build/reference/configuration/#locales)に準拠しています。
+
+```ts
+// サイトのデフォルトロケールを設定します。
+export const DEFAULT_LOCALE_SETTING: string = "en";
+
+export const LOCALES_SETTING: LocaleSetting = {
+  // サポートするロケールを追加または削除します。
+  en: {
+    label: "English",
+    lang: "en-US", // 任意
+  },
+  ja: {
+    label: "日本語",
+  },
+  "zh-cn": {
+    label: "简体中文",
+    lang: "zh-CN",
+  },
+  ar: {
+    label: "العربية",
+    dir: "rtl", // 任意
+  },
+};
+```
+
+言語コードに関する情報は以下のリンクを参照してください。
+
+> [lang - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+
+### 2. astro.config.mjs の設定
+
+`site`にあなたのサイトのURLを設定します。
 
 ```diff
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from './src/locales';
 
-// https://astro.build/config
 export default defineConfig({
-  site: 'https://astro-i18n-starter.pages.dev',
-  integrations: [mdx(), sitemap()],
+- site: 'https://astro-i18n-starter.pages.dev',
++ site: 'https://your-site.com',
   i18n: {
-+   defaultLocale: 'ja',
-+   locales: ['en', 'ja', 'zh-cn', 'ar'],
-    routing: {
-      prefixDefaultLocale: true,
-      redirectToDefaultLocale: false,
-    },
+  defaultLocale: DEFAULT_LOCALE_SETTING,
+  locales: Object.keys(LOCALES_SETTING),
+  routing: {
+    prefixDefaultLocale: true,
+    redirectToDefaultLocale: false,
   },
-  markdown: {
-    shikiConfig: {
-      theme: 'one-dark-pro',
-    },
   },
-});
+...
 ```
 
-astroの詳細な設定方法については公式ドキュメントを参考にしてください。
+Astro の詳細な設定オプションについては公式ドキュメントを参照してください。
 
-> [Configuration Reference | Docs](https://docs.astro.build/en/reference/configuration-reference/)
+* [Configuration Reference | Docs](https://docs.astro.build/en/reference/configuration-reference/)
+* [Internationalization (i18n) Routing | Docs](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
 
-> [Internationalization (i18n) Routing | Docs](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
+注: `prefixDefaultLocale` と `redirectToDefaultLocale` の設定を変更することは推奨されません。{ SITE_TITLE } ではクライアントサイドのJavascriptでリダイレクトを管理しており、URLにlocaleが含まれていない場合はデフォルトのlocaleにリダイレクトします。例えば、`/setup/` は `/en/setup/` にリダイレクトされます。
 
-`prefixDefaultLocale`, `redirectToDefaultLocale` の設定を変えることはおすすめしません。{ SITE_TITLE } ではクライアント再度のJavascriptでリダイレクト処理を管理しており、URLにlocaleが含まれていない場合はデフォルトのlocaleにリダイレクトします。例えば `/setup/` は `/en/setup/` にリダイレクトされます。
-
-
-### 2. /src/locales.ts の設定
-同様にして { SITE_TITLE } の設定ファイルを更新します。
-
-`DEFAULT_LOCALE_SETTING`に先ほど設定したデフォルトロケールを、`LOCALES_SETTING`には作成したいロケールのリストを設定します。こちらは[Starlightの`locales`設定](https://starlight.astro.build/reference/configuration/#locales) に準拠しています。
-
-```ts
-export const DEFAULT_LOCALE_SETTING = "en";
-
-export const LOCALES_SETTING: LocaleSetting = {
-  "en": {
-    "label": "English"
-  },
-  "ja": {
-    "label": "日本語"
-  },
-  "zh-cn": {
-    "label": "简体中文",
-    "lang": "zh-CN"
-  },
-  "ar": {
-    "label": "العربية",
-    "dir": "rtl"
-  },
-};
-
-interface LocaleSetting {
-  [key: Lowercase<string>]: {
-    label: string;
-    lang?: string;
-    dir?: 'rtl' | 'ltr';
-  };
- }
-```
-
-langコードについてはこちらをご確認ください。
-
-> [lang - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
 
 
 ## ディレクトリ構造
 
 [Astroのディレクトリ構造](https://docs.astro.build/en/basics/project-structure/)に準拠します。
 
-
 ```text
 src/
 ├── assets/
 │   └── en/, ja/ ...
+├── blog/
+│   └── en/, ja/ ...
 ├── components/
 │   └── i18n/
-├── content/
-│   │  blog/
-│   └── config.ts
 ├── layouts/
 ├── pages/
-│   └── [lang]/
-│   └── en/, ja/ ...
+│   ├── [lang]/
+│   ├── en/, ja/ ...
+│   ├── 404.astro
+│   └── index.astro
 ├── styles/
+├── content.config.ts
 ├── consts.ts
 ├── i18n.ts
 └── locales.ts
 ```
 
 ### src/components/i18n
-
-多言語対応サイトで使用するUIコンポーネントのフォルダです。
+多言語対応サイトで使用するUIコンポーネントのディレクトリです
 
 ### src/pages
-
-- `src/pages/[lang]/` 配下のファイルはひとつの`.astro`ファイルから、動的に各言語のhtmlファイルを生成します
-- `src/pages/en/`、`src/pages/ja/`などのフォルダからはそれぞれの言語のhtmlファイルを生成できます
+- `src/pages/[lang]/` 以下のファイルは、単一の `.astro` ファイルから各言語のHTMLファイルを動的に生成します。
+- `src/pages/en/`、`src/pages/ja/` などのディレクトリから各言語のHTMLファイルをそれぞれ生成することもできます。
 
 ### src/consts.ts
-
 プロジェクト内でimportして使用できる定数データのファイルです。使用しないこともできます。
 
 ### src/i18n.ts
-
 { SITE_TITLE } で使用している関数などの定義ファイルです。基本的に編集する必要はありません。

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+
+const getRobotsTxt = (sitemapURL: URL) => `
+User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+	const sitemapURL = new URL("sitemap-index.xml", site);
+	return new Response(getRobotsTxt(sitemapURL));
+};

--- a/src/pages/zh-cn/page.mdx
+++ b/src/pages/zh-cn/page.mdx
@@ -1,31 +1,32 @@
 ---
 layout: "@/layouts/Article.astro"
 title: "添加页面"
-description: "关于添加和管理多语言页面等"
+description: "关于添加和管理多语言页面"
 ---
 import PageHeadline from "@/components/PageHeadline.astro";
 import { SITE_TITLE } from "@/consts";
 
 <PageHeadline title={frontmatter.title} />
 
-有几种方法可以使用 { SITE_TITLE } 创建多语言页面。
+在 { SITE_TITLE } 中，有几种方法可以创建多语言页面。
 
 
-## 如果想要按语言分开文件
 
-在 `pages` 目录下，按语言创建文件夹，并使用 Astro 或 Markdown 格式添加文件。
+## 如果想为每种语言分开文件
+
+在 `pages` 目录下为每种语言创建文件夹，并以 Astro 格式或 Markdown 格式添加文件。
 
 ```text
 src/pages
 ├── en/
-│   └── page-1.astro
+│   ├── page-1.astro
 │   └── page-2.mdx
 └── ja/
-  └── page-1.astro
+  ├── page-1.astro
   └── page-2.mdx
 ```
 
-将生成以下页面：
+将生成以下页面
 
 * /en/page-1/index.html
 * /en/page-2/index.html
@@ -33,18 +34,19 @@ src/pages
 * /ja/page-2/index.html
 
 
-## 如果想要在一个文件中管理
 
-如果内容不是很多，可以使用 [Astro 的动态路由](https://docs.astro.build/en/guides/routing/#dynamic-routes) 功能，从一个文件动态生成各语言的页面。
+## 如果想在一个文件中管理
+
+如果页面内容不多，可以使用 [Astro 的动态路由](https://docs.astro.build/en/guides/routing/#dynamic-routes) 功能，从一个文件动态生成各语言的页面。
 
 ```text
 src/pages
 └── [lang]/
-    └── page-1.astro
+    ├── page-1.astro
     └── page-2.astro
 ```
 
-在文件中导入 `LOCALES` 对象，并使用 Astro 的 `getStaticPaths()` 函数生成动态路由。
+在文件中导入 `LOCALES` 对象，并通过 Astro 的 `getStaticPaths()` 函数生成动态路由。
 
 ```astro
 ---
@@ -57,53 +59,54 @@ export const getStaticPaths = () =>
 ---
 ```
 
-将生成以下页面：
+将生成以下页面
 
 * /en/page-1/index.html
 * /en/page-2/index.html
 * /ja/page-1/index.html
 * /ja/page-2/index.html
 
-## 如果想要使用 Content Collection
 
-如果想要使用 Markdown 文件管理博客或新闻等页面，可以使用 [Astro 的内容集合](https://docs.astro.build/en/guides/content-collections/) 功能。
+
+## 如果想利用 Content Collection
+
+如果想用 Markdown 文件管理博客或新闻等页面，可以利用 Astro 的内容集合功能。
 
 #### 目录结构
 
 ```text
 src/
-├── content/
-│   ├── config.ts
-│   ├── blog/en/
-│   │   └── first-post.md
+├── content.config.ts
+├── blog/
+│   ├── en/
+│   │   ├── first-post.md
 │   │   └── second-post.md
-│   └── blog/ja/
-│        └── first-post.md
+│   └── ja/
+│        ├── first-post.md
 │        └── second-post.md
 └── pages/[lang]/blog/
-  └── index.astro
-  └── [...slug].astro
+  ├── index.astro
+  └── [...id].astro
 ```
 
-#### pages/[lang]/blog/[...slug].astro
+#### pages/[lang]/blog/[...id].astro
 
 ```astro
 ---
-import Layout from "@/layouts/Article.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
 
   return posts.map((post) => {
-    const [lang, ...slug] = post.slug.split("/");
-    return { params: { lang, slug: slug.join("/") || undefined }, props: post };
+    const [lang, ...id] = post.id.split("/");
+    return { params: { lang, id: id.join("/") || undefined }, props: post };
   });
 }
 ---
 ```
 
 
-请查阅 Astro 文档以获取更多详细信息。
+详情请参阅 Astro 文档。
 
-> [内容集合 | 文档](https://docs.astro.build/en/guides/content-collections/)
+> [Content Collections | Docs](https://docs.astro.build/en/guides/content-collections/)

--- a/src/pages/zh-cn/setup.mdx
+++ b/src/pages/zh-cn/setup.mdx
@@ -9,111 +9,104 @@ import { SITE_TITLE } from "@/consts";
 <PageHeadline title={frontmatter.title} />
 
 
+
 ## 项目创建
 
 ```sh
 npm create astro@latest -- --template psephopaiktes/astro-i18n-starter
 ```
 
+
+
 ## 配置
 
+### 1. 配置 /src/locales.ts
 
-### 1. 配置 astro.config.mjs
+首先，更新语言设置文件。
 
-在 astro 配置文件中设置 `defaultLocale` 和 `locales`。
+在 `DEFAULT_LOCALE_SETTING` 中设置默认语言，并在 `LOCALES_SETTING` 中设置所需语言列表。这遵循 [Starlight 配置](https://starlight.astro.build/reference/configuration/#locales)。
+
+```ts
+// 设置站点的默认语言。
+export const DEFAULT_LOCALE_SETTING: string = "en";
+
+export const LOCALES_SETTING: LocaleSetting = {
+    // 添加或删除支持的语言。
+    en: {
+        label: "English",
+        lang: "en-US", // 可选
+    },
+    ja: {
+        label: "日本語",
+    },
+    "zh-cn": {
+        label: "简体中文",
+        lang: "zh-CN",
+    },
+    ar: {
+        label: "العربية",
+        dir: "rtl", // 可选
+    },
+};
+```
+
+有关语言代码的信息，请参阅以下链接。
+
+> [lang - HTML: 超文本标记语言 | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+
+### 2. 配置 astro.config.mjs
+
+在 `site` 中设置您的 URL。
 
 ```diff
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from './src/locales';
 
-// https://astro.build/config
 export default defineConfig({
-    site: 'https://astro-i18n-starter.pages.dev',
-    integrations: [mdx(), sitemap()],
-    i18n: {
-+   defaultLocale: 'en',
-+   locales: ['en', 'ja', 'zh-cn', 'ar'],
-        routing: {
-            prefixDefaultLocale: true,
-            redirectToDefaultLocale: false,
-        },
+- site: 'https://astro-i18n-starter.pages.dev',
++ site: 'https://your-site.com',
+  i18n: {
+    defaultLocale: DEFAULT_LOCALE_SETTING,
+    locales: Object.keys(LOCALES_SETTING),
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: false,
     },
-    markdown: {
-        shikiConfig: {
-            theme: 'one-dark-pro',
-        },
-    },
-});
+  },
+...
 ```
 
 有关 Astro 的详细配置选项，请参阅官方文档。
 
-> [配置参考 | 文档](https://docs.astro.build/zh-cn/reference/configuration-reference/)
+* [配置参考 | 文档](https://docs.astro.build/en/reference/configuration-reference/)
+* [国际化 (i18n) 路由 | 文档](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)
 
-> [国际化 (i18n) 路由 | 文档](https://docs.astro.build/zh-cn/guides/internationalization/#configure-i18n-routing)
+注意：不建议更改 `prefixDefaultLocale` 和 `redirectToDefaultLocale` 的设置。{ SITE_TITLE } 使用客户端 JavaScript 管理重定向过程。如果 URL 不包含语言，将重定向到默认语言。例如，`/setup/` 将重定向到 `/en/setup/`。
 
-不建议更改 `prefixDefaultLocale` 和 `redirectToDefaultLocale` 的设置。{ SITE_TITLE } 使用客户端 JavaScript 管理重定向过程。如果 URL 不包含语言环境，则会重定向到默认语言环境。例如，`/setup/` 将重定向到 `/en/setup/`。
-
-
-### 2. 配置 /src/locales.ts
-
-同样，更新 { SITE_TITLE } 的配置文件。
-
-在 `DEFAULT_LOCALE_SETTING` 中设置默认语言环境，在 `LOCALES_SETTING` 中设置所需语言环境的列表。这遵循 [Starlight 的 `locales` 配置](https://starlight.astro.build/reference/configuration/#locales)。
-
-```ts
-export const DEFAULT_LOCALE_SETTING = "en";
-
-export const LOCALES_SETTING: LocaleSetting = {
-    "en": {
-        "label": "English"
-    },
-    "ja": {
-        "label": "日本語"
-    },
-    "zh-cn": {
-        "label": "简体中文",
-        "lang": "zh-CN"
-    },
-    "ar": {
-        "label": "العربية",
-        "dir": "rtl"
-    },
-};
-
-interface LocaleSetting {
-    [key: Lowercase<string>]: {
-        label: string;
-        lang?: string;
-        dir?: 'rtl' | 'ltr';
-    };
- }
-```
-
-有关语言代码的信息，请参阅以下链接。
-
-> [lang - HTML: 超文本标记语言 | MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/lang)
 
 
 ## 项目结构
 
-遵循 [Astro 项目结构](https://docs.astro.build/zh-cn/basics/project-structure/)。
+遵循 [Astro 项目结构](https://docs.astro.build/en/basics/project-structure/)。
 
 ```text
 src/
 ├── assets/
 │   └── en/, ja/ ...
+├── blog/
+│   └── en/, ja/ ...
 ├── components/
 │   └── i18n/
-├── content/
-│   │  blog/
-│   └── config.ts
 ├── layouts/
 ├── pages/
-│   └── [lang]/
-│   └── en/, ja/ ...
+│   ├── [lang]/
+│   ├── en/, ja/ ...
+│   ├── 404.astro
+│   └── index.astro
 ├── styles/
+├── content.config.ts
 ├── consts.ts
 ├── i18n.ts
 └── locales.ts
@@ -121,17 +114,17 @@ src/
 
 ### src/components/i18n
 
-用于多语言网站中使用的 UI 组件的目录。
+用于多语言网站的 UI 组件目录。
 
 ### src/pages
 
-- `src/pages/[lang]/` 下的文件会从单个 `.astro` 文件动态生成每个语言环境的 HTML 文件。
-- 您可以从类似 `src/pages/en/`、`src/pages/ja/` 的文件夹中生成每种语言的 HTML 文件。
+- `src/pages/[lang]/` 下的文件从单个 `.astro` 文件动态生成每种语言的 HTML 文件。
+- 您也可以从 `src/pages/en/`、`src/pages/ja/` 等文件夹生成每种语言的 HTML 文件。
 
 ### src/consts.ts
 
-用于在项目中导入和使用的常量数据的文件。如果不需要，也可以省略此文件。
+可以在项目中导入和使用的常量数据文件。如果不需要，也可以省略。
 
 ### src/i18n.ts
 
-包含在 { SITE_TITLE } 中使用的函数的定义的文件。通常情况下，不需要编辑此文件。
+包含 { SITE_TITLE } 中使用的函数定义的文件。通常不需要编辑此文件。

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,53 +1,58 @@
-/* basic page style */
+/* basic site style */
 
 :lang(ar) {
-  * { letter-spacing: 0 !important; }
+	* {
+		letter-spacing: 0 !important;
+	}
 }
 
 :root {
-  @media (prefers-color-scheme: dark) {
-    --color-theme: #ef4d1a;
-    --color-accent: #943e0d;
-    --color-base: #342c28;
-    --color-main: #faf9f6;
-    --color-caution: #FFAA2B;
-  }
-  @media (prefers-color-scheme: light) {
-    --color-theme: #ef4d1a;
-    --color-accent: #ffcc21;
-    --color-base: #faf9f6;
-    --color-main: #342c28;
-    --color-caution: #A80A00;
-  }
+	@media (prefers-color-scheme: dark) {
+		--color-theme: #ef4d1a;
+		--color-accent: #943e0d;
+		--color-base: #342c28;
+		--color-main: #faf9f6;
+		--color-caution: #ffaa2b;
+	}
+	@media (prefers-color-scheme: light) {
+		--color-theme: #ef4d1a;
+		--color-accent: #ffcc21;
+		--color-base: #faf9f6;
+		--color-main: #342c28;
+		--color-caution: #a80a00;
+	}
 
-  --sp-l: 64px;
-  --sp-m: 32px;
-  --sp-s: 16px;
-  @media (width < 480px) {
-    --sp-l: 48px;
-    --sp-m: 16px;
-    --sp-s: 8px;
-  }
+	--sp-l: 64px;
+	--sp-m: 32px;
+	--sp-s: 16px;
+	@media (width < 480px) {
+		--sp-l: 48px;
+		--sp-m: 16px;
+		--sp-s: 8px;
+	}
 
-  --english-font: "Noto Sans", "Robot", "Avenir Next", "Avenir", "Century Gothic", "SF Pro Text", "Arial", -apple-system, BlinkMacSystemFont, sans-serif;
+	--english-font: "Noto Sans", "Robot", "Avenir Next", "Avenir",
+		"Century Gothic", "SF Pro Text", "Arial", -apple-system, BlinkMacSystemFont,
+		sans-serif;
 
-  color: var(--color-main);
-  background-color: var(--color-base);
-  accent-color: var(--color-theme);
+	color: var(--color-main);
+	background-color: var(--color-base);
+	accent-color: var(--color-theme);
 
-  background-image: radial-gradient(
-    color-mix(in srgb, var(--color-main) 10%, transparent) 1px,
-    var(--color-base) 1px
-  );
-  background-size: 16px 16px;
+	background-image: radial-gradient(
+		color-mix(in srgb, var(--color-main) 10%, transparent) 1px,
+		var(--color-base) 1px
+	);
+	background-size: 16px 16px;
 
-  line-height: 1.6;
-  font-weight: 500;
-  font-size: 18px;
-  font-family: "Noto Sans", system-ui, "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif;
-  @media (width < 480px) {
-    font-size: 16px;
-  }
+	line-height: 1.6;
+	font-weight: 500;
+	font-size: 18px;
+	font-family: "Noto Sans", system-ui, "SF Pro Text", -apple-system,
+		BlinkMacSystemFont, sans-serif;
+	@media (width < 480px) {
+		font-size: 16px;
+	}
 }
 
 h1,
@@ -57,42 +62,42 @@ h4,
 button,
 input,
 label {
-  line-height: 1.4;
+	line-height: 1.4;
 }
 
 p {
-  margin-block-start: 0.8em;
+	margin-block-start: 0.8em;
 }
 
 p a {
-  color: var(--color-theme);
-  text-decoration: underline;
+	color: var(--color-theme);
+	text-decoration: underline;
 }
 
 a,
 button {
-  transition: 0.2s ease-out;
-  &:hover,
-  &:active {
-    transition: 0.2s ease-out;
-  }
+	transition: 0.2s ease-out;
+	&:hover,
+	&:active {
+		transition: 0.2s ease-out;
+	}
 }
 
 svg,
 path {
-  fill: currentColor;
-  aspect-ratio: 1;
+	fill: currentColor;
+	aspect-ratio: 1;
 }
 
 [class^="material-icons"] {
-  vertical-align: middle;
-  font-size: 1.1em;
-  line-height: 1;
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  overflow: hidden;
-  &:dir(rtl).dir {
-    scale: -1 1;
-  }
+	vertical-align: middle;
+	font-size: 1.1em;
+	line-height: 1;
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	overflow: hidden;
+	&:dir(rtl).dir {
+		scale: -1 1;
+	}
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,19 +1,20 @@
 /* define the layout and structure of the entire page */
 
-.l-header {}
+.l-header {
+}
 
 .l-main {
-  margin-block-start: var(--sp-l);
+	margin-block-start: var(--sp-l);
 }
 
 .l-content {
-  max-inline-size: 800px;
-  padding-inline: var(--sp-m);
-  margin-inline: auto;
+	max-inline-size: 800px;
+	padding-inline: var(--sp-m);
+	margin-inline: auto;
 }
 
 .l-footer {
-  position: sticky;
-  top: 100vh;
-  margin-block-start: calc(var(--sp-l) * 2);
+	position: sticky;
+	top: 100vh;
+	margin-block-start: calc(var(--sp-l) * 2);
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -3,19 +3,18 @@
 *,
 *::before,
 *::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
 }
 
 :root {
-  scroll-behavior: smooth;
-  -moz-text-size-adjust: none;
-  -webkit-text-size-adjust: none;
-  text-size-adjust: none;
-  font-smoothing: antialiased;
-  hanging-punctuation: allow-end;
-  word-break: auto-phrase;
+	scroll-behavior: smooth;
+	-moz-text-size-adjust: none;
+	-webkit-text-size-adjust: none;
+	text-size-adjust: none;
+	hanging-punctuation: allow-end;
+	word-break: auto-phrase;
 }
 
 body,
@@ -28,65 +27,65 @@ figure,
 blockquote,
 dl,
 dd {
-  margin: 0;
+	margin: 0;
 }
 
 ul,
 ol {
-  list-style: none;
+	list-style: none;
 }
 
 body {
-  min-height: 100vh;
+	min-height: 100vh;
 }
 
 h1,
 h2,
 h3,
 h4 {
-  text-wrap: pretty;
+	text-wrap: pretty;
 }
 
 a {
-  text-decoration-skip-ink: none;
-  color: currentColor;
-  text-decoration: none;
-  word-break: break-all;
+	text-decoration-skip-ink: none;
+	color: currentColor;
+	text-decoration: none;
+	word-break: break-all;
 }
 
 p a {
-  text-decoration: underline;
+	text-decoration: underline;
 }
 
 img,
 picture {
-  border: none;
-  vertical-align: top;
-  max-width: 100%;
-  height: auto;
-  font-style: italic;
+	border: none;
+	vertical-align: top;
+	max-width: 100%;
+	height: auto;
+	font-style: italic;
 }
 
 input,
 button,
 textarea,
 select {
-  font: inherit;
+	font: inherit;
 }
 
 textarea:not([rows]) {
-  min-height: 3em;
+	min-height: 3em;
 }
 
 b,
 strong {
-  font-weight: bolder;
+	font-weight: bolder;
 }
 
 table {
-  table-layout: fixed;
-  border-collapse: collapse;
-  width: 100%;
+	table-layout: fixed;
+	border-collapse: collapse;
+	width: 100%;
 }
 
 a,
@@ -98,30 +97,30 @@ label,
 select,
 summary,
 textarea {
-  touch-action: manipulation;
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  letter-spacing: inherit;
+	touch-action: manipulation;
+	font-family: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	letter-spacing: inherit;
 }
 
 button {
-  cursor: pointer;
-  background: none;
-  border: none;
-  font-size: inherit;
-  color: inherit;
+	cursor: pointer;
+	background: none;
+	border: none;
+	font-size: inherit;
+	color: inherit;
 }
 
 :target {
-  scroll-margin-block: 5ex;
+	scroll-margin-block: 5ex;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
+	* {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
 }


### PR DESCRIPTION
* Fixed robots.txt to be generated dynamically.  
* Updated to use [@astrojs/sitemap](https://docs.astro.build/ja/guides/integrations-guide/sitemap/#i18n), enabling i18n support for sitemap.xml.  
* Language settings can now be configured in a single place.  
* Updated the content of the description page.  
* Various minor bug fixes.  